### PR TITLE
Ensure an Old Version of Pillow is installed that doesn't break things

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask
 flask_bootstrap4
 qrcode
 pdf2image
+Pillow==9.*


### PR DESCRIPTION
Pillow 10.x seemed to cause a whole bunch of rendering problems. Ensuring Pillow 9.x gets installed seems to fix it.